### PR TITLE
Also allow Guzzle 7 as laravel 8 requires it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "psr/http-client": "^1.0"
     },
     "license": "LGPL-3.0-only",


### PR DESCRIPTION
langleyfoxall/laravel-nist-password-rules uses this package, but I can't upgrade to laravel 8 as laravel 8 requires guzzle 7.

On a side note Guzzle 7 implements PSR-18

I made a PR to paragonie/certainty to allow Guzzle 7 too